### PR TITLE
add Flag.DisablePrintDefault to suppress printing the default value in usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
   * [Installing this fork for cobra](#installing-this-fork-for-cobra)
 * [Documentation](#documentation)
   * [Setting no option default values for flags](#setting-no-option-default-values-for-flags)
+  * [Disable printing default value](#disable-printing-default-value)
   * [Command line flag syntax](#command-line-flag-syntax)
   * [Mutating or "Normalizing" Flag names](#mutating-or-normalizing-flag-names)
   * [Deprecating a flag or its shorthand](#deprecating-a-flag-or-its-shorthand)
@@ -71,6 +72,23 @@ Would result in something like
 | --flagname=1357  | ip=1357         |
 | --flagname       | ip=4321         |
 | [nothing]        | ip=1234         |
+
+### Disable printing default value
+
+The printing of a flag's default value can be suppressed with `Flag.DisablePrintDefault`.
+
+**Example**:
+
+``` go
+flag.Int("in", -1, "help message")
+flag.Lookup("in").DisablePrintDefault = true
+```
+
+**Output**:
+
+``` plain
+  --in int   help message
+```
 
 ### Command line flag syntax
 

--- a/flag.go
+++ b/flag.go
@@ -101,6 +101,7 @@ type Flag struct {
 	Usage               string              // help message
 	UsageType           string              // flag type displayed in the help message
 	DisableUnquoteUsage bool                // toggle unquoting and extraction of type from usage
+	DisablePrintDefault bool                // toggle printing of the default value in usage message
 	Value               Value               // value as set
 	DefValue            string              // default value (as text); for usage message
 	Changed             bool                // If the user set the value (or if left to default)
@@ -724,7 +725,7 @@ func (f *FlagSet) FlagUsagesWrapped(cols int) string {
 		}
 
 		line += usage
-		if !flag.defaultIsZeroValue() {
+		if !flag.DisablePrintDefault && !flag.defaultIsZeroValue() {
 			if flag.Value.Type() == "string" {
 				line += fmt.Sprintf(" (default %q)", flag.DefValue)
 			} else {

--- a/flag_test.go
+++ b/flag_test.go
@@ -1308,6 +1308,7 @@ const defaultOutput = `      --A                         for bootstrapping, allo
       --Z int                     an int that defaults to zero
       --custom custom             custom Value implementation
       --customP custom            a VarP with default (default 10)
+      --disableDefault int        A non-zero int with DisablePrintDefault
       --maxT timeout              set timeout for dial
   -v, --verbose count             verbosity
 `
@@ -1351,6 +1352,8 @@ func TestPrintDefaults(t *testing.T) {
 	fs.StringSlice("StringSlice", []string{}, "string slice with zero default")
 	fs.StringArray("StringArray", []string{}, "string array with zero default")
 	fs.CountP("verbose", "v", "verbosity")
+	fs.Int("disableDefault", -1, "A non-zero int with DisablePrintDefault")
+	fs.Lookup("disableDefault").DisablePrintDefault = true
 
 	var cv customValue
 	fs.Var(&cv, "custom", "custom Value implementation")


### PR DESCRIPTION
<!-- Contributor License Notice :

By opening a pull request and making a contribution to this project, you certify that:

(a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or

(b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or

(c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.

(d) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.

-->

### Changes purposed in this pull request

Sometimes it's convenient to not print the default value.

see spf13/pflag#291

### Checklist

- [x] Tests have been added and/or updated
- [x] `go fmt .` has been run
- [x] `go vet .` has been run

<!-- Optional :
### A gif to brighten your reviewer's day and/or represents how you feel about this pull request

![](place-image-url-here)
-->
